### PR TITLE
Refactor learn page and add tutorial subpages

### DIFF
--- a/pages/learn.py
+++ b/pages/learn.py
@@ -4,124 +4,15 @@ from air_markdown import TailwindTypographyMarkdown as Markdown
 
 def render(request: air.Request):
     return air.Children(
-        air.Title("Air: The New FastAPI-Powered Python Web Framework (2025)"),
+        air.Title("Learn: Air Python Web Framework"),
+        Markdown("""
+# Learn
 
-    Markdown("""# Learn
+Welcome to the Air Learn section! Choose a topic below:
 
-Here are the tutorials for learning Air. While not necessary, it helps if you have experience with [FastAPI](https://fastapi.tiangolo.com/).
+- [Quickstart](learn_quickstart)
+- [Tutorial 1: Combining FastAPI and Air](learn_tutorial_1)
 
-
-## Installation
-
-Install using `pip install -U air` or `conda install air -c conda-forge`.
-
-For `uv` users, just create a virtualenv and install the air package, like:
-
-```sh
-uv venv
-source .venv/bin/activate
-uv add air
-uv add fastapi[standard]
-```
-
-## A Simple Example
-
-Create a `main.py` with:
-
-```python
-import air
-
-app = air.Air()
-
-
-@app.get("/")
-async def index():
-    return air.layouts.mvpcss(air.H1("Hello, world!", style="color: blue;"))
-```
-
-Serve with this command-line action:
-
-```python
-fastapi dev
-```
-<br>
+More tutorials coming soon!
 """),
-
-Markdown("""
-## Combining FastAPI and Air
-
-Air is just a layer over FastAPI. So it is trivial to combine sophisticated HTML pages and a REST API into one app. 
-
-```python
-import air
-from fastapi import FastAPI
-
-app = air.Air()
-api = FastAPI()
-
-@app.get("/")
-def landing_page():
-    return air.layouts.mvpcss(
-        air.Head(air.Title("Awesome SaaS")),
-        air.Body(
-            air.H1("Awesome SaaS"),
-            air.P(air.A("API Docs", target="_blank", href="/api/docs")),
-        ),
     )
-
-
-@api.get("/")
-def api_root():
-    return {"message": "Awesome SaaS is powered by FastAPI"}
-
-# Combining the Air and and FastAPI apps into one
-app.mount("/api", api)
-```
-<br>
-"""),
-Markdown("""
-## Combining FastAPI and Air using Jinja2
-
-Want to use Jinja2 instead of Air Tags? We've got you covered.
-
-```python
-import air
-from fastapi import FastAPI
-
-app = air.Air()
-api = FastAPI()
-
-# Air's JinjaRenderer is a shortcut for using Jinja templates
-jinja = air.JinjaRenderer(directory="templates")
-
-@app.get("/")
-def index(request: Request):
-    return jinja(request, name="home.html")
-
-@api.get("/")
-def api_root():
-    return {"message": "Awesome SaaS is powered by FastAPI"}
-
-# Combining the Air and and FastAPI apps into one
-app.mount("/api", api)    
-```
-
-Don't forget the Jinja template!
-
-```html
-<!doctype html
-<html>
-    <head>
-        <title>Awesome SaaS</title>
-    </head>
-    <body>
-        <h1>Awesome SaaS</h1>
-        <p>
-            <a target="_blank" href="/api/docs">API Docs</a>
-        </p>
-    </body>
-</html>
-```    """)
-
-
-)        

--- a/pages/learn_quickstart.py
+++ b/pages/learn_quickstart.py
@@ -1,0 +1,45 @@
+import air
+from air_markdown import TailwindTypographyMarkdown as Markdown
+
+def render(request: air.Request):
+    return air.Children(
+        air.Title("Learn > Quickstart"),
+        Markdown("""# Quickstart
+
+Here are the tutorials for learning Air. While not necessary, it helps if you have experience with [FastAPI](https://fastapi.tiangolo.com/).
+
+## Installation
+
+Install using `pip install -U air` or `conda install air -c conda-forge`.
+
+For `uv` users, just create a virtualenv and install the air package, like:
+
+```sh
+uv venv
+source .venv/bin/activate
+uv add air
+uv add fastapi[standard]
+```
+
+## A Simple Example
+
+Create a `main.py` with:
+
+```python
+import air
+
+app = air.Air()
+
+@app.get("/")
+async def index():
+    return air.layouts.mvpcss(air.H1("Hello, world!", style="color: blue;"))
+```
+
+Serve with this command-line action:
+
+```python
+fastapi dev
+```
+<br>
+"""),
+    )

--- a/pages/learn_tutorial_1.py
+++ b/pages/learn_tutorial_1.py
@@ -1,0 +1,80 @@
+import air
+from air_markdown import TailwindTypographyMarkdown as Markdown
+
+def render(request: air.Request):
+    return air.Children(
+        air.Title("Learn > Tutorial 1: Combining FastAPI and Air"),
+        Markdown("""# Tutorial 1: Combining FastAPI and Air
+
+Air is just a layer over FastAPI. So it is trivial to combine sophisticated HTML pages and a REST API into one app. 
+
+```python
+import air
+from fastapi import FastAPI
+
+app = air.Air()
+api = FastAPI()
+
+@app.get("/")
+def landing_page():
+    return air.layouts.mvpcss(
+        air.Head(air.Title("Awesome SaaS")),
+        air.Body(
+            air.H1("Awesome SaaS"),
+            air.P(air.A("API Docs", target="_blank", href="/api/docs")),
+        ),
+    )
+
+@api.get("/")
+def api_root():
+    return {"message": "Awesome SaaS is powered by FastAPI"}
+
+# Combining the Air and and FastAPI apps into one
+app.mount("/api", api)
+```
+<br>
+"""),
+        Markdown("""## Using Jinja2 with Air
+
+Want to use Jinja2 instead of Air Tags? We've got you covered.
+
+```python
+import air
+from fastapi import FastAPI
+
+app = air.Air()
+api = FastAPI()
+
+# Air's JinjaRenderer is a shortcut for using Jinja templates
+jinja = air.JinjaRenderer(directory="templates")
+
+@app.get("/")
+def index(request: Request):
+    return jinja(request, name="home.html")
+
+@api.get("/")
+def api_root():
+    return {"message": "Awesome SaaS is powered by FastAPI"}
+
+# Combining the Air and and FastAPI apps into one
+app.mount("/api", api)    
+```
+
+Don't forget the Jinja template!
+
+```html
+<!doctype html
+<html>
+    <head>
+        <title>Awesome SaaS</title>
+    </head>
+    <body>
+        <h1>Awesome SaaS</h1>
+        <p>
+            <a target="_blank" href="/api/docs">API Docs</a>
+        </p>
+    </body>
+</html>
+```
+"""),
+    )


### PR DESCRIPTION
Simplifies pages/learn.py to a landing page with links to tutorials.

Moves Quickstart and Tutorial 1 content into new dedicated files: pages/learn_quickstart.py and pages/learn_tutorial_1.py for better maintainability, and to encourage the writing of more tutorials.