### PR TITLE
fix: capitalize Pydantic

### DIFF
--- a/pages/about/alternatives.md
+++ b/pages/about/alternatives.md
@@ -14,7 +14,7 @@ Django pioneered high-quality, accessible documentation. That and its pluggable 
 
 > #### Django inspires Air to
 >
-> 1. Incorporate an HTML form validation system powered by pydantic
+> 1. Incorporate an HTML form validation system powered by Pydantic
 > 2. Add a pluggable system for supporting an ecosystem of third-party packages
 > 3. Include user management as an early pluggable package.
 

--- a/pages/concepts/forms.md
+++ b/pages/concepts/forms.md
@@ -45,7 +45,7 @@ async def add(request: air.Request):
 
 ## Air Forms
 
-Air Forms are powered by pydantic. That includes both their display and validation of data. If you have any experience with pydantic, that will go a long way towards helping your understanding of Air Forms.
+Air Forms are powered by Pydantic. That includes both their display and validation of data. If you have any experience with Pydantic, that will go a long way towards helping your understanding of Air Forms.
 
 ### A Sample Contact Air Form
 

--- a/pages/learn/quickstart.md
+++ b/pages/learn/quickstart.md
@@ -66,7 +66,7 @@ def show_item():
 
 ## Form validation with Air Forms
 
-Built on pydantic's `BaseModel`, the `air.AirForm` class is used to validate data coming from HTML forms.
+Built on Pydantic's `BaseModel`, the `air.AirForm` class is used to validate data coming from HTML forms.
 
 ```python
 from typing import Annotated

--- a/pages/why.py
+++ b/pages/why.py
@@ -59,7 +59,7 @@ Okay, here's why you might want to use Air:
 - **Jinja Friendly** - No need to write `response_class=HtmlResponse` and `templates.TemplateResponse` for every HTML view
 - **Mix Jinja and Air Tags** - Jinja and Air Tags both are first class citizens. Use either or both in the same view!
 - **HTMX friendly** - We love HTMX and provide utilities to use it with Air
-- **HTML form validation powered by Pydantic** - We love using Pydantic to validate incoming data. Air Forms provide two ways to use pydantic with HTML forms (dependency injection or from within views)
+- **HTML form validation powered by Pydantic** - We love using Pydantic to validate incoming data. Air Forms provide two ways to use Pydantic with HTML forms (dependency injection or from within views)
 - **Built-in SVG support** - SVGs aren't an afterthought, they are part of core Air and can be accessed via the `air.svgs` namespace
 - **Code formatting and linting (PEP8)** - To maintain code quality and consistency, Air enforces Ruff formatting and linting across its entire codebase
 - **Easy to learn yet well documented** - Hopefully Air is so intuitive and well-typed you'll barely need to use the documentation. In case you do need to look something up we're taking our experience writing technical books and using it to make the best documentation we can.


### PR DESCRIPTION
Pydantic should be capitalized as a proper noun across all files (except when referring to its module name, such as in `import pydantic`).

Closes #37. (The issue mentioned fixing capitalization in `pages/concepts/forms.md`—I've also corrected it across 3 other files.)