### PR TITLE
Update AirMarkdown import and dependency naming

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import importlib
 from pathlib import Path
 
 import air
-from air_markdown.tags import AirMarkdown
+from AirMarkdown.tags import AirMarkdown
 from fastapi import HTTPException
 import sentry_sdk
 from os import getenv

--- a/pages/charts.py
+++ b/pages/charts.py
@@ -2,7 +2,7 @@ import json
 import random
 
 import air
-from air_markdown.tags import AirMarkdown
+from AirMarkdown.tags import AirMarkdown
 
 
 def sorted_random_list():

--- a/pages/why.py
+++ b/pages/why.py
@@ -1,7 +1,7 @@
 from random import sample
 
 import air
-from air_markdown.tags import AirMarkdown
+from AirMarkdown.tags import AirMarkdown
 
 
 def reasons_not_to_use_air():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "air>=0.16",
-    "air-markdown>=0.3.0",
+    "AirMarkdown>=0.3.0",
     "fastapi[standard]>=0.116.0",
     "mistletoe>=1.4.0",
     "mkdocstrings[python]>=0.29.1",


### PR DESCRIPTION
Changed all imports and dependency references from 'air_markdown' to 'AirMarkdown' in main.py, charts.py, why.py, and pyproject.toml to match the updated package/module name.

Draft pending PyPI update