### PR TITLE
Add `just dev`

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,8 @@
+# Run in development mode with reload
+dev: 
+    @lsof -ti tcp:8000 | xargs kill -9 || true
+    uv run fastapi dev main.py --reload
+
 # Run all the formatting, linting, and testing commands
 qa:
     markdownlint-cli2 "**/*.md"


### PR DESCRIPTION
This pull request adds a new development convenience command to the `justfile`. The new `dev` command allows you to run the FastAPI application in development mode with automatic reload, and ensures that any previous process on port 8000 is killed before starting.

* Development workflow improvement:
  * Added a `dev` recipe to the `justfile` that kills any process running on port 8000 and starts FastAPI in development mode with reload enabled.