### PR TITLE
Update quickstart instructions for Air setup

### DIFF
--- a/pages/learn/quickstart.md
+++ b/pages/learn/quickstart.md
@@ -11,8 +11,8 @@ mkdir helloair
 cd helloair
 uv venv
 source .venv/bin/activate
-uv add air
-uv add fastapi[standard]
+uv init
+uv add "air[standard]"
 ```
 
 > [!TIP]


### PR DESCRIPTION
Add 'uv init' because you need a pyproject.toml to do `uv add`, and update package addition to 'air[standard]'